### PR TITLE
3 allow creating component through the cli

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "environmental"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/mental.yaml
+++ b/mental.yaml
@@ -11,8 +11,17 @@ components:
   values:
   - name: VALUE_ONE
     value: ONE
-mappings:
-- path: .
-  components:
-  - postgres
-  - test
+- name: test2
+  prefix: pre
+  values:
+  - name: keyone
+    value: one
+  - name: keytwo
+    value: two
+- name: test2
+  prefix: pre
+  values:
+  - name: keyone
+    value: one
+  - name: keytwo
+    value: two

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -52,5 +52,14 @@ pub(crate) enum Commands {
         target: Option<PathBuf>,
     },
     /// List components
+    Component {
+        #[command(subcommand)]
+        component: Component,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+pub(crate) enum Component {
     List {},
+    Create {},
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -60,17 +60,24 @@ pub(crate) enum Commands {
 
 #[derive(Subcommand, Debug)]
 pub(crate) enum Component {
+    /// List existing components
     List {},
+
+    /// Create a new component
     Create {
-        #[arg(short, long, value_name = "name")]
+        /// Name of the component
+        #[arg(value_name = "name")]
         name: String,
 
+        /// optional prefix
         #[arg(short, long, value_name = "prefix")]
         prefix: Option<String>,
 
+        /// keys, seperated by whitespace
         #[clap(short, long, value_parser, num_args = 1.., value_delimiter = ' ')]
         keys: Vec<String>,
 
+        /// values, seperated by whitespace
         #[clap(short, long, value_parser, num_args = 1.., value_delimiter = ' ')]
         values: Vec<String>,
     },

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -70,7 +70,7 @@ pub(crate) enum Component {
         name: String,
 
         /// optional prefix
-        #[arg(short, long, value_name = "prefix")]
+        #[arg(value_name = "prefix")]
         prefix: Option<String>,
 
         /// keys, seperated by whitespace

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -61,5 +61,17 @@ pub(crate) enum Commands {
 #[derive(Subcommand, Debug)]
 pub(crate) enum Component {
     List {},
-    Create {},
+    Create {
+        #[arg(short, long, value_name = "name")]
+        name: String,
+
+        #[arg(short, long, value_name = "prefix")]
+        prefix: Option<String>,
+
+        #[clap(short, long, value_parser, num_args = 1.., value_delimiter = ' ')]
+        keys: Vec<String>,
+
+        #[clap(short, long, value_parser, num_args = 1.., value_delimiter = ' ')]
+        values: Vec<String>,
+    },
 }

--- a/src/components.rs
+++ b/src/components.rs
@@ -35,4 +35,20 @@ impl Component {
         }
         formatted_values
     }
+
+    pub(crate) fn new(
+        name: String,
+        prefix: Option<String>,
+        values: Vec<(String, String)>,
+    ) -> Component {
+        let mut given_key_values: Vec<KeyValue> = Vec::new();
+        for (key, value) in values {
+            given_key_values.push(KeyValue { name: key, value })
+        }
+        Component {
+            name,
+            prefix,
+            values: given_key_values,
+        }
+    }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -53,7 +53,7 @@ impl MentalConfig {
         Ok(config)
     }
 
-    fn create_component(
+    pub fn create_component(
         mut self,
         name: String,
         values: Vec<(String, String)>,
@@ -62,7 +62,7 @@ impl MentalConfig {
         Ok(())
     }
 
-    fn create_component_with_prefix(
+    pub fn create_component_with_prefix(
         mut self,
         name: String,
         prefix: String,

--- a/src/config.rs
+++ b/src/config.rs
@@ -52,4 +52,24 @@ impl MentalConfig {
         let config: MentalConfig = from_str(&config_input)?;
         Ok(config)
     }
+
+    fn create_component(
+        mut self,
+        name: String,
+        values: Vec<(String, String)>,
+    ) -> Result<(), Box<dyn Error>> {
+        self.components.push(Component::new(name, None, values));
+        Ok(())
+    }
+
+    fn create_component_with_prefix(
+        mut self,
+        name: String,
+        prefix: String,
+        values: Vec<(String, String)>,
+    ) -> Result<(), Box<dyn Error>> {
+        self.components
+            .push(Component::new(name, Some(prefix), values));
+        Ok(())
+    }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -61,6 +61,7 @@ impl MentalConfig {
         name: String,
         values: Vec<(String, String)>,
     ) -> Result<Self, Box<dyn Error>> {
+        // TODO: Check if the component is already present to prevent duplicated components
         self.components.push(Component::new(name, None, values));
         Ok(self)
     }
@@ -71,6 +72,7 @@ impl MentalConfig {
         prefix: String,
         values: Vec<(String, String)>,
     ) -> Result<Self, Box<dyn Error>> {
+        // TODO: Check if the component is already present to prevent duplicated components
         self.components
             .push(Component::new(name, Some(prefix), values));
         Ok(self)

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,6 +4,7 @@ use schemars::{schema_for, JsonSchema};
 use serde::{Deserialize, Serialize};
 use serde_yaml::from_str;
 use std::error::Error;
+use std::fmt;
 use std::fs::read_to_string;
 use std::fs::File;
 use std::io::Write;
@@ -15,6 +16,17 @@ pub struct MentalConfig {
 }
 
 impl FileIO for MentalConfig {}
+
+#[derive(Debug, Clone)]
+struct ConfigError(String);
+
+impl fmt::Display for ConfigError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Invalid config option: {}", self.0)
+    }
+}
+
+impl Error for ConfigError {}
 
 impl MentalConfig {
     pub(crate) fn to_env(&self, component_keys: &[String]) -> Vec<String> {
@@ -56,14 +68,26 @@ impl MentalConfig {
         Ok(config)
     }
 
+    pub fn name_exists(&self, name: &String) -> bool {
+        for comp in &self.components {
+            if name == &comp.name {
+                return true;
+            }
+        }
+        false
+    }
+
     pub fn create_component(
         mut self,
         name: String,
         values: Vec<(String, String)>,
     ) -> Result<Self, Box<dyn Error>> {
-        // TODO: Check if the component is already present to prevent duplicated components
-        self.components.push(Component::new(name, None, values));
-        Ok(self)
+        if self.name_exists(&name) {
+            Err(Box::new(ConfigError("Name already exists".into())))
+        } else {
+            self.components.push(Component::new(name, None, values));
+            Ok(self)
+        }
     }
 
     pub fn create_component_with_prefix(
@@ -72,9 +96,12 @@ impl MentalConfig {
         prefix: String,
         values: Vec<(String, String)>,
     ) -> Result<Self, Box<dyn Error>> {
-        // TODO: Check if the component is already present to prevent duplicated components
-        self.components
-            .push(Component::new(name, Some(prefix), values));
-        Ok(self)
+        if self.name_exists(&name) {
+            Err(Box::new(ConfigError("Name already exists".into())))
+        } else {
+            self.components
+                .push(Component::new(name, Some(prefix), values));
+            Ok(self)
+        }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,5 @@
 use crate::components::Component;
+use crate::mapping::FileIO;
 use schemars::{schema_for, JsonSchema};
 use serde::{Deserialize, Serialize};
 use serde_yaml::from_str;
@@ -12,6 +13,8 @@ use std::path::{Path, PathBuf};
 pub struct MentalConfig {
     components: Vec<Component>,
 }
+
+impl FileIO for MentalConfig {}
 
 impl MentalConfig {
     pub(crate) fn to_env(&self, component_keys: &[String]) -> Vec<String> {
@@ -57,9 +60,9 @@ impl MentalConfig {
         mut self,
         name: String,
         values: Vec<(String, String)>,
-    ) -> Result<(), Box<dyn Error>> {
+    ) -> Result<Self, Box<dyn Error>> {
         self.components.push(Component::new(name, None, values));
-        Ok(())
+        Ok(self)
     }
 
     pub fn create_component_with_prefix(
@@ -67,9 +70,9 @@ impl MentalConfig {
         name: String,
         prefix: String,
         values: Vec<(String, String)>,
-    ) -> Result<(), Box<dyn Error>> {
+    ) -> Result<Self, Box<dyn Error>> {
         self.components
             .push(Component::new(name, Some(prefix), values));
-        Ok(())
+        Ok(self)
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,6 +52,10 @@ fn main() {
             } => {
                 println!("Creating component");
 
+                if keys.len() == 0 && values.len() == 0 {
+                    panic!("No keys and values given. Aborting creation of component")
+                }
+
                 if keys.len() != values.len() {
                     panic!("Number of keys and values is not equal.")
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,8 +43,41 @@ fn main() {
                     println!("  {}", &c)
                 }
             }
-            cli::Component::Create {} => {
-                println!("Creating component")
+            cli::Component::Create {
+                name,
+                prefix,
+                keys,
+                values,
+            } => {
+                println!("Creating component");
+
+                let mut key_values: Vec<(String, String)> = Vec::new();
+                let key_value_iterator = keys.iter().zip(values.iter());
+
+                for (key, value) in key_value_iterator {
+                    key_values.push((key.to_owned(), value.to_owned()))
+                }
+
+                match prefix {
+                    Some(prefix) => {
+                        match mental_config.create_component_with_prefix(
+                            name.to_owned(),
+                            prefix.to_owned(),
+                            key_values,
+                        ) {
+                            Ok(_) => {
+                                println!("Created component with prefix")
+                            }
+                            Err(_) => panic!("Error creating component"),
+                        }
+                    }
+                    None => match mental_config.create_component(name.to_owned(), key_values) {
+                        Ok(_) => {
+                            println!("Created component")
+                        }
+                        Err(_) => panic!("Error creating component"),
+                    },
+                }
             }
         },
         Some(cli::Commands::Map { target }) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use crate::{config::MentalConfig, mapping::MentalMapping};
 use clap::Parser;
-use std::path::{Path, PathBuf};
 use mapping::FileIO;
+use std::path::{Path, PathBuf};
 
 mod cli;
 mod components;
@@ -69,20 +69,22 @@ fn main() {
                         ) {
                             Ok(config) => {
                                 println!("Created component with prefix");
-                                config.dump(&config_file.to_path_buf()).expect("Error writing config");
+                                config
+                                    .dump(&config_file.to_path_buf())
+                                    .expect("Error writing config");
                             }
-                            Err(_) => panic!("Error creating component"),
+                            Err(err) => panic!("Error creating component {}", err),
                         }
                     }
-                    None => {
-                        match mental_config.create_component(name.to_owned(), key_values) {
-                            Ok(config) => {
-                                println!("Created component");
-                                config.dump(&config_file.to_path_buf()).expect("Error writing config");
-                            }
-                            Err(_) => panic!("Error creating component"),
+                    None => match mental_config.create_component(name.to_owned(), key_values) {
+                        Ok(config) => {
+                            println!("Created component");
+                            config
+                                .dump(&config_file.to_path_buf())
+                                .expect("Error writing config");
                         }
-                    }
+                        Err(err) => panic!("Error creating component {}", err),
+                    },
                 };
             }
         },

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,8 +52,8 @@ fn main() {
             } => {
                 println!("Creating component");
 
-                if keys.len() == values.len() {
-                    panic!("Number of keys and values is equal.")
+                if keys.len() != values.len() {
+                    panic!("Number of keys and values is not equal.")
                 }
                 let mut key_values: Vec<(String, String)> = Vec::new();
                 for (key, value) in keys.iter().zip(values.iter()) {
@@ -67,19 +67,23 @@ fn main() {
                             prefix.to_owned(),
                             key_values,
                         ) {
-                            Ok(_) => {
-                                println!("Created component with prefix")
+                            Ok(config) => {
+                                println!("Created component with prefix");
+                                config.dump(&config_file.to_path_buf()).expect("Error writing config");
                             }
                             Err(_) => panic!("Error creating component"),
                         }
                     }
-                    None => match mental_config.create_component(name.to_owned(), key_values) {
-                        Ok(_) => {
-                            println!("Created component")
+                    None => {
+                        match mental_config.create_component(name.to_owned(), key_values) {
+                            Ok(config) => {
+                                println!("Created component");
+                                config.dump(&config_file.to_path_buf()).expect("Error writing config");
+                            }
+                            Err(_) => panic!("Error creating component"),
                         }
-                        Err(_) => panic!("Error creating component"),
-                    },
-                }
+                    }
+                };
             }
         },
         Some(cli::Commands::Map { target }) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 use crate::{config::MentalConfig, mapping::MentalMapping};
 use clap::Parser;
 use std::path::{Path, PathBuf};
+use mapping::FileIO;
 
 mod cli;
 mod components;
@@ -51,10 +52,11 @@ fn main() {
             } => {
                 println!("Creating component");
 
+                if keys.len() == values.len() {
+                    panic!("Number of keys and values is equal.")
+                }
                 let mut key_values: Vec<(String, String)> = Vec::new();
-                let key_value_iterator = keys.iter().zip(values.iter());
-
-                for (key, value) in key_value_iterator {
+                for (key, value) in keys.iter().zip(values.iter()) {
                     key_values.push((key.to_owned(), value.to_owned()))
                 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,13 +35,18 @@ fn main() {
                 MentalConfig::create_schema(target).expect("Error writing file");
             }
         },
-        Some(cli::Commands::List {}) => {
-            let components = mental_config.list_components();
-            println!("Existing components:");
-            for c in components {
-                println!("  {}", &c)
+        Some(cli::Commands::Component { component }) => match component {
+            cli::Component::List {} => {
+                let components = mental_config.list_components();
+                println!("Existing components:");
+                for c in components {
+                    println!("  {}", &c)
+                }
             }
-        }
+            cli::Component::Create {} => {
+                println!("Creating component")
+            }
+        },
         Some(cli::Commands::Map { target }) => {
             let target_path = match target {
                 None => match config_file.parent() {


### PR DESCRIPTION
It is now possible to create new components through the cli by running:

```
Usage: environmental component create [OPTIONS] --name <name>

Options:
  -n, --name <name>
  -p, --prefix <prefix>
  -k, --keys <KEYS>...
  -v, --values <VALUES>...
  -h, --help                Print help
```