### PR TITLE
Feat/allow int values

### DIFF
--- a/mental.yaml
+++ b/mental.yaml
@@ -25,3 +25,15 @@ components:
     value: one
   - name: keytwo
     value: two
+- name: test3
+  prefix: pre
+  values:
+  - name: keyone
+    value: one
+  - name: keytwo
+    value: two
+- name: test4
+  prefix: pre
+  values:
+  - name: keyone
+    value: '1'

--- a/mental.yaml
+++ b/mental.yaml
@@ -3,7 +3,7 @@ components:
   prefix: POSTGRES
   values:
   - name: PORT
-    value: '5333'
+    value: 5333
   - name: SCHEME
     value: TEST
 - name: test

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -71,10 +71,10 @@ pub(crate) enum Component {
     /// List existing components
     List {},
 
-    /// Show a component
+    /// Print components
     Show {
         /// Components to show (whitespace sperated)
-        #[clap(value_parser, num_args =1.., value_delimiter = ' ')]
+        #[clap(value_parser, num_args =1.., value_delimiter = ' ', required=true)]
         names: Vec<String>,
     },
 
@@ -89,11 +89,11 @@ pub(crate) enum Component {
         prefix: Option<String>,
 
         /// keys, seperated by whitespace
-        #[clap(short, long, value_parser, num_args = 1.., value_delimiter = ' ')]
+        #[clap(short, long, value_parser, num_args = 1.., value_delimiter = ' ', required=true)]
         keys: Vec<String>,
 
         /// values, seperated by whitespace
-        #[clap(short, long, value_parser, num_args = 1.., value_delimiter = ' ')]
+        #[clap(short, long, value_parser, num_args = 1.., value_delimiter = ' ', required=true)]
         values: Vec<String>,
     },
 

--- a/src/components.rs
+++ b/src/components.rs
@@ -3,13 +3,12 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Deserialize, Serialize,JsonSchema)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
 #[serde(untagged)]
 pub enum StringOrInt {
     Integer(u32),
     String(String),
 }
-
 
 /// Struct holding the key and values
 ///
@@ -27,7 +26,7 @@ impl KeyValue {
         match &self.value {
             StringOrInt::String(v) => {
                 format!(r#"{0}="{1}""#, self.name, v.to_owned())
-            },
+            }
             StringOrInt::Integer(v) => {
                 let value_as_string = v.to_string();
                 format!(r#"{0}={1}"#, self.name, value_as_string)
@@ -77,11 +76,14 @@ impl Component {
     ) -> Component {
         let mut given_key_values: Vec<KeyValue> = Vec::new();
         for (key, value) in values {
-            let parsed_value : StringOrInt = match value.parse::<u32>() {
+            let parsed_value: StringOrInt = match value.parse::<u32>() {
                 Ok(v) => StringOrInt::Integer(v),
-                Err(v) => StringOrInt::String(v.to_string())
+                Err(v) => StringOrInt::String(v.to_string()),
             };
-            given_key_values.push(KeyValue { name: key, value: parsed_value })
+            given_key_values.push(KeyValue {
+                name: key,
+                value: parsed_value,
+            })
         }
         Component {
             name,

--- a/src/components.rs
+++ b/src/components.rs
@@ -3,6 +3,18 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+#[derive(Debug, Deserialize, Serialize,JsonSchema)]
+pub enum StringOrInt {
+    String(String),
+    Integer(u32)
+}
+
+impl std::fmt::Display for StringOrInt {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f,"{}",self)
+    }
+}
+
 /// Struct holding the key and values
 ///
 /// * `name`: name of the value
@@ -10,7 +22,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
 struct KeyValue {
     name: String,
-    value: String,
+    value: StringOrInt,
 }
 
 impl KeyValue {
@@ -61,7 +73,11 @@ impl Component {
     ) -> Component {
         let mut given_key_values: Vec<KeyValue> = Vec::new();
         for (key, value) in values {
-            given_key_values.push(KeyValue { name: key, value })
+            let parsed_value : StringOrInt = match value.parse::<u32>() {
+                Ok(v) => StringOrInt::Integer(v),
+                Err(v) => StringOrInt::String(v.to_string())
+            };
+            given_key_values.push(KeyValue { name: key, value: parsed_value })
         }
         Component {
             name,

--- a/src/components.rs
+++ b/src/components.rs
@@ -4,16 +4,12 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize, Serialize,JsonSchema)]
+#[serde(untagged)]
 pub enum StringOrInt {
+    Integer(u32),
     String(String),
-    Integer(u32)
 }
 
-impl std::fmt::Display for StringOrInt {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f,"{}",self)
-    }
-}
 
 /// Struct holding the key and values
 ///
@@ -28,7 +24,15 @@ struct KeyValue {
 impl KeyValue {
     /// Format the key value to .env format
     fn to_env(&self) -> String {
-        format!(r#"{0}="{1}""#, self.name, self.value)
+        match &self.value {
+            StringOrInt::String(v) => {
+                format!(r#"{0}="{1}""#, self.name, v.to_owned())
+            },
+            StringOrInt::Integer(v) => {
+                let value_as_string = v.to_string();
+                format!(r#"{0}={1}"#, self.name, value_as_string)
+            }
+        }
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,5 @@
 use crate::components::Component;
+use crate::components::StringOrInt;
 use crate::mapping::FileIO;
 use schemars::{schema_for, JsonSchema};
 use serde::{Deserialize, Serialize};

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,4 @@
 use crate::components::Component;
-use crate::components::StringOrInt;
 use crate::mapping::FileIO;
 use schemars::{schema_for, JsonSchema};
 use serde::{Deserialize, Serialize};

--- a/src/mapping.rs
+++ b/src/mapping.rs
@@ -5,7 +5,6 @@ use crate::config::MentalConfig;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_yaml::from_str;
-use std::error::Error;
 use std::fs;
 use std::fs::read_to_string;
 use std::fs::File;
@@ -37,7 +36,7 @@ pub trait FileIO: serde::Serialize {
     /// * `target`: target file to write into
     fn dump(&self, target: &PathBuf) -> std::io::Result<()> {
         let mut file = File::create(target)?;
-        let struct_as_string = serde_yaml::to_string(self).expect("Error writing config");
+        let struct_as_string = serde_yaml::to_string(self).unwrap();
         file.write_all(struct_as_string.as_bytes())?;
         Ok(())
     }
@@ -45,7 +44,7 @@ pub trait FileIO: serde::Serialize {
     /// Load the given struct from a file
     ///
     /// * `struct_file`: file that contains the struct in a serialized format
-    fn from_file(struct_file: &&Path) -> Result<Self, Box<dyn Error>>
+    fn from_file(struct_file: &&Path) -> Result<Self, Box<dyn std::error::Error>>
     where
         Self: Sized,
         for<'a> Self: Deserialize<'a>,


### PR DESCRIPTION
It is possible to handle union types with serde. This should make it possible to read numeric values with serde from the config file. 

Add a new formatter function to handle the matching of the enum types that are introduces in this PR.